### PR TITLE
Add Links field to ValidationError and export "conflicting_resource_id"

### DIFF
--- a/gc.go
+++ b/gc.go
@@ -134,7 +134,12 @@ func (err *APIError) Error() string {
 }
 
 type ValidationError struct {
-	Message        string `json:"message"`
-	Field          string `json:"field"`
-	RequestPointer string `json:"request_pointer"`
+	Message        string     `json:"message"`
+	Field          string     `json:"field"`
+	RequestPointer string     `json:"request_pointer"`
+	Links          ErrorLinks `json:"links"`
+}
+
+type ErrorLinks struct {
+	ConflictingResourceID string `json:"conflicting_resource_id"`
 }


### PR DESCRIPTION
Hi, everyone. It seems like the `links` field was missing inside the definition of `ValidationError`. This `PR` adds a new type definition (`ErrorLinks`) to be able to parse `conflicting_resource_id` when using idempotency keys