### PR TITLE
add missing customer bank account field to the validation error

### DIFF
--- a/gc.go
+++ b/gc.go
@@ -163,4 +163,5 @@ type ValidationError struct {
 
 type ErrorLinks struct {
 	ConflictingResourceID string `json:"conflicting_resource_id"`
+	CustomerBankAccount   string `json:"customer_bank_account"`
 }


### PR DESCRIPTION
There is a missing field in the validation errors.

Doc: https://developer.gocardless.com/api-reference#errors-validation-errors