### PR TITLE
Add pull_request trigger to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: test
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,16 @@ jobs:
           exit 1
       - name: Run go vet
         run: go vet ./...
+
+  all-tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [tests, code-quality]
+    if: always()
+    steps:
+      - name: Check tests/code-quality job status
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ] || [ "${{ needs.code-quality.result }}" != "success" ]; then
+            echo "tests or code-quality job did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger alongside the existing `push` trigger so `tests`/`code-quality` run against fork PRs, not just pushes to the repo.
- Restricts the `push` trigger to `master` only.

## Why
Part of IX-2323: setting up required status checks across GoCardless's public client library repos so we can safely enable auto-merge. A push-only trigger never runs against a fork PR's head commit, so requiring `tests`/`code-quality` in branch protection would otherwise block every external contribution.

## Test plan
- [ ] Confirm `tests` and `code-quality` appear as checks on this PR