### PR TITLE
Add auto-merge for client-library-templates changes

### DIFF
--- a/.github/workflows/auto-merge-client-library-changes.yml
+++ b/.github/workflows/auto-merge-client-library-changes.yml
@@ -1,0 +1,14 @@
+name: Auto-merge client-library changes
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  pull-requests: write
+
+jobs:
+  run:
+    uses: gocardless/github-actions/.github/workflows/auto-merge-client-library-changes.yml@master
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: go vet ./...
 
   all-tests-passed:
-    name: All tests passed
+    name: all-tests-passed
     runs-on: ubuntu-latest
     needs: [tests, code-quality]
     if: always()


### PR DESCRIPTION
## Summary
- Adds a caller workflow (schedule + workflow_dispatch) that invokes the reusable `auto-merge-client-library-changes` workflow in gocardless/github-actions (see gocardless/github-actions#503).
- That workflow merges the automated "Changes from gocardless/client-library-templates" PR once 24h have passed since the last commit was pushed to it.

## Context
gocardless-ci-robot now bypasses the review requirement (but not required status checks) on this repo's branch protection (gocardless/anu#48800), so it can merge these PRs on its own once that lands. This workflow won't actually be able to merge anything until that PR is applied.

## Test plan
- [x] Validated YAML syntax
- [x] Validated the reusable workflow's discovery/age logic against this repo's real open template-changes PR (see gocardless/github-actions#503 for details)
- [ ] Depends on gocardless/anu#48800 being merged and applied before it can do anything