### PR TITLE
IX 2322 automate merging updates from client-library-templates

### DIFF
--- a/.github/workflows/auto-merge-client-library-changes.yml
+++ b/.github/workflows/auto-merge-client-library-changes.yml
@@ -1,0 +1,22 @@
+name: Auto-merge client-library changes
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'gocardless-ci-robot[bot]' && github.event.pull_request.head.ref == 'template-changes' }}
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GOCARDLESS_CI_ROBOT_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,6 +33,25 @@ jobs:
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Extract changelog notes for this version
+        id: notes
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          NOTES=""
+          if [ -f CHANGELOG.md ]; then
+            NOTES=$(awk -v ver="$VERSION" '
+              $0 ~ "^## " ver {p=1; next}
+              p && /^## / {exit}
+              p {print}
+            ' CHANGELOG.md)
+          fi
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create tag and release
         if: steps.check.outputs.should_release == 'true'
         run: |
@@ -40,6 +59,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag v${{ steps.version.outputs.version }}
           git push origin v${{ steps.version.outputs.version }}
-          gh release create v${{ steps.version.outputs.version }} --generate-notes
+          NOTES="${{ steps.notes.outputs.notes }}"
+          if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
+            gh release create v${{ steps.version.outputs.version }} --notes "$NOTES"
+          else
+            gh release create v${{ steps.version.outputs.version }} --generate-notes
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GOCARDLESS_CI_ROBOT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: go vet ./...
 
   all-tests-passed:
-    name: All tests passed
+    name: all-tests-passed
     runs-on: ubuntu-latest
     needs: [tests, code-quality]
     if: always()


### PR DESCRIPTION
These two changes are only tangentially related, but I thought it would reduce noise to put them on a single PR.

This PR:

* extracts the relevant part of CHANGELOG.md to use as the notes for the GitHub release
* automatically merges the template-changes PRs that client-library-templates creates, as long as the tests pass