### PR TITLE
Explicitly set release title so it matches the tag name

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -57,13 +57,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag v${{ steps.version.outputs.version }}
-          git push origin v${{ steps.version.outputs.version }}
+          TAG="v${{ steps.version.outputs.version }}"
+          git tag "$TAG"
+          git push origin "$TAG"
           NOTES="${{ steps.notes.outputs.notes }}"
           if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
-            gh release create v${{ steps.version.outputs.version }} --notes "$NOTES"
+            gh release create "$TAG" --title "$TAG" --notes "$NOTES"
           else
-            gh release create v${{ steps.version.outputs.version }} --generate-notes
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GOCARDLESS_CI_ROBOT_TOKEN }}


### PR DESCRIPTION
## Summary
* `gh release create` was leaving the release title blank when notes come from the changelog (`--notes`), so GitHub fell back to showing the merge commit message as the title instead of e.g. "v1.2.3".
* Both branches of the release-creation step now pass `--title` explicitly so it always matches the tag name.

This mirrors the same fix applied in gocardless-nodejs (gocardless/gocardless-nodejs#256).

## Test plan
- [ ] Confirm the next automated release gets the correct title